### PR TITLE
Fix alias references for cross-package types

### DIFF
--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -64,10 +64,12 @@ func BuildDependencyGraph(result *analyzer.AnalysisResult) *DependencyGraph {
 	// 型解析器の初期化
 	typeResolver := analyzer.NewTypeResolver()
 
+	aliasMap := buildAliasMap(result)
+
 	// 依存関係抽出（戦略パターンを使用）
 	extractors := []DependencyExtractor{
-		NewFieldDependencyExtractor(typeResolver),
-		&SignatureDependencyExtractor{},
+		NewFieldDependencyExtractor(typeResolver, aliasMap),
+		NewSignatureDependencyExtractor(aliasMap),
 		&BodyCallDependencyExtractor{},
 		NewCrossPackageDependencyExtractor(),
 	}
@@ -92,10 +94,12 @@ func BuildDependencyGraphWithPackages(result *analyzer.AnalysisResult, targetDir
 	// 型解析器の初期化
 	typeResolver := analyzer.NewTypeResolver()
 
+	aliasMap := buildAliasMap(result)
+
 	// 依存関係抽出（戦略パターンを使用）
 	extractors := []DependencyExtractor{
-		NewFieldDependencyExtractor(typeResolver),
-		&SignatureDependencyExtractor{},
+		NewFieldDependencyExtractor(typeResolver, aliasMap),
+		NewSignatureDependencyExtractor(aliasMap),
 		&BodyCallDependencyExtractor{},
 		NewCrossPackageDependencyExtractor(),
 		NewPackageDependencyExtractor(targetDir),


### PR DESCRIPTION
## Summary
- track import aliases per package when building the graph
- resolve aliased type references for struct fields and function signatures
- expand tests with alias-based cross-package type references

## Testing
- `go test ./...`
- `go run . analyze --include-package-deps ./testdata/multi-package`


------
https://chatgpt.com/codex/tasks/task_e_68431057364c8329911abe8cbe4c916d